### PR TITLE
Revert "Change tutorial URL in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 #### [Example Applications](https://github.com/Sonata-Princeton/SONATA-DEV/tree/master/sonata/examples)
 
-#### [Tutorials](https://github.com/Sonata-Princeton/SONATA-DEV/tree/master/sonata/tutorials)
+#### [Tutorials](https://github.com/Sonata-Princeton/SONATA-DEV/tree/tutorial/sonata/tutorials)


### PR DESCRIPTION
Reverts Sonata-Princeton/SONATA-DEV#36. 

The PR #35 was meant to fix a bug in the tutorials. But it was merged in the **master branch**. But the tutorials link in the README of the **master branch** opens up the tutorial folder in the **tutorial branch**. 

Hence, the PR #36 changed the tutorials link in the README to open up the tutorial folder in the **master branch**. But then PR #36 got merged into the **tutorial branch**.

This PR reverts the PR #36.

I'm sorry for this mess. I'll submit a PR for the **tutorial branch** making the corrections in the tutorial folder.