### PR TITLE
Modify receive.py to resolve bugs

### DIFF
--- a/sonata/tutorials/Tutorial-2/receive.py
+++ b/sonata/tutorials/Tutorial-2/receive.py
@@ -132,7 +132,6 @@ class Emitter(object):
                     if line:
                         m = re.search('.*\[(.*)\]\=\s+(.*)', line)
                         if m:
-                            print "index = ", m.group(1), "value = ", m.group(2)
                             output[m.group(1)] = m.group(2)
                             write_register_cmds += "register_write " + register + " " + str(m.group(1)) + " 0\n"
 


### PR DESCRIPTION
This PR aims to resolve 3 bugs:
1. The logging file handler used wrong name of the directory.
2. `tuple_dict` is the data structure used to store the information from the packets that arrive. Till now, it was a dictionary with an index that produced bugs in some scenarios. Now the dictionary is indexed with `qid`.
3. The regex match object `m = re.search('.*\[(.*)\]\=\s+(.*)', line)` is now checked before using it.