### PR TITLE
Add missing dependencies to basic-setup.sh

### DIFF
--- a/setup/basic-setup.sh
+++ b/setup/basic-setup.sh
@@ -15,7 +15,7 @@ sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential fakeroot debhelper autoconf \
 automake libssl-dev graphviz python-all python-qt4 \
 python-twisted-conch libtool git tmux vim python-pip python-paramiko \
-python-sphinx mongodb dos2unix wireshark mysql-server
+python-sphinx mongodb dos2unix wireshark mysql-server libmysqlclient-dev
 
 sudo -H pip install -U pip
 sudo pip install --upgrade scipy
@@ -23,7 +23,7 @@ sudo -H pip install -r ~/dev/setup/pip-basic-requires
 
 sudo apt-get install -y ssh git emacs sshfs graphviz feh Protobuf
 sudo apt-get install -y libstring-crc32-perl xterm
-sudo -H pip install mysql-connector==2.1.4
+sudo -H pip install mysql-connector==2.1.7
 
 echo 'Defaults    env_keep += "PYTHONPATH"' | sudo tee --append /etc/sudoers
 echo 'PATH=$PATH:~/iSDX/bin' >> ~/.profile


### PR DESCRIPTION
When following your [installation guide](https://github.com/Sonata-Princeton/SONATA-DEV/blob/tutorial/installation.md) and your [first tutorial](https://github.com/Sonata-Princeton/SONATA-DEV/tree/tutorial/sonata/tutorials/Tutorial-1), the Vagrant installation is missing two components:
- `mysql_config` is not installed (solution: install `libmysqlclient-dev`)
- `mysql-connector` is not available in the requested version (solution: increase the version)

Error logs when installing using the `basic-setup.sh`:
```
ERROR: Could not find a version that satisfies the requirement mysql-connector==2.1.4 (from versions: 2.1.7, 2.2.9)
ERROR: No matching distribution found for mysql-connector==2.1.4
```

In principle, it would be nice to fail prominently when provisioning the Vagrant VM. For example by enabling  `set -eu` in the setup scripts. This ensures that, when one command fails (or a variable is accessed but not defined), the script itself exits with a non-zero exit code => it stops the provisioning of the VM and outputs the error.
This makes it easier to see the problems in the thousands of lines of output.